### PR TITLE
Make server configurable.

### DIFF
--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/config/AgentCoreEngineConfiguration.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/config/AgentCoreEngineConfiguration.java
@@ -78,7 +78,6 @@ public class AgentCoreEngineConfiguration {
         private final Integer hosaEndpointPort;
         private final String hosaEndpointUsername;
         private final String hosaEndpointPassword;
-        private final Boolean hosaEndpointUseSSL;
         private final String hosaEndpointSecurityRealm;
 
         public StorageAdapterConfiguration(
@@ -102,7 +101,6 @@ public class AgentCoreEngineConfiguration {
                 Integer hosaEndpointPort,
                 String hosaEndpointUsername,
                 String hosaEndpointPassword,
-                Boolean hosaEndpointUseSSL,
                 String hosaEndpointSecurityRealm) {
             super();
             this.type = type;
@@ -125,7 +123,6 @@ public class AgentCoreEngineConfiguration {
             this.hosaEndpointPort = hosaEndpointPort;
             this.hosaEndpointUsername = hosaEndpointUsername;
             this.hosaEndpointPassword = hosaEndpointPassword;
-            this.hosaEndpointUseSSL = hosaEndpointUseSSL;
             this.hosaEndpointSecurityRealm = hosaEndpointSecurityRealm;
         }
 
@@ -215,10 +212,6 @@ public class AgentCoreEngineConfiguration {
 
         public String getHosaEndpointPassword() {
             return hosaEndpointPassword;
-        }
-
-        public Boolean getHosaEndpointUseSSL() {
-            return hosaEndpointUseSSL;
         }
 
         public String getHosaEndpointSecurityRealm() {

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/config/AgentCoreEngineConfiguration.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/config/AgentCoreEngineConfiguration.java
@@ -74,6 +74,13 @@ public class AgentCoreEngineConfiguration {
         private final int connectTimeoutSeconds;
         private final int readTimeoutSeconds;
 
+        private final String hosaEndpointAddress;
+        private final Integer hosaEndpointPort;
+        private final String hosaEndpointUsername;
+        private final String hosaEndpointPassword;
+        private final Boolean hosaEndpointUseSSL;
+        private final String hosaEndpointSecurityRealm;
+
         public StorageAdapterConfiguration(
                 StorageReportTo type,
                 String username,
@@ -90,7 +97,13 @@ public class AgentCoreEngineConfiguration {
                 String keystorePassword,
                 String securityRealm,
                 int connectTimeoutSeconds,
-                int readTimeoutSeconds) {
+                int readTimeoutSeconds,
+                String hosaEndpointAddress,
+                Integer hosaEndpointPort,
+                String hosaEndpointUsername,
+                String hosaEndpointPassword,
+                Boolean hosaEndpointUseSSL,
+                String hosaEndpointSecurityRealm) {
             super();
             this.type = type;
             this.username = username;
@@ -108,6 +121,12 @@ public class AgentCoreEngineConfiguration {
             this.securityRealm = securityRealm;
             this.connectTimeoutSeconds = connectTimeoutSeconds;
             this.readTimeoutSeconds = readTimeoutSeconds;
+            this.hosaEndpointAddress = hosaEndpointAddress;
+            this.hosaEndpointPort = hosaEndpointPort;
+            this.hosaEndpointUsername = hosaEndpointUsername;
+            this.hosaEndpointPassword = hosaEndpointPassword;
+            this.hosaEndpointUseSSL = hosaEndpointUseSSL;
+            this.hosaEndpointSecurityRealm = hosaEndpointSecurityRealm;
         }
 
         public StorageReportTo getType() {
@@ -182,6 +201,29 @@ public class AgentCoreEngineConfiguration {
             return readTimeoutSeconds;
         }
 
+        public String getHosaEndpointAddress() {
+            return hosaEndpointAddress;
+        }
+
+        public Integer getHosaEndpointPort() {
+            return hosaEndpointPort;
+        }
+
+        public String getHosaEndpointUsername() {
+            return hosaEndpointUsername;
+        }
+
+        public String getHosaEndpointPassword() {
+            return hosaEndpointPassword;
+        }
+
+        public Boolean getHosaEndpointUseSSL() {
+            return hosaEndpointUseSSL;
+        }
+
+        public String getHosaEndpointSecurityRealm() {
+            return hosaEndpointSecurityRealm;
+        }
     }
 
     public static class DiagnosticsConfiguration {

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/HawkularStorageAdapter.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/HawkularStorageAdapter.java
@@ -62,6 +62,7 @@ public class HawkularStorageAdapter implements StorageAdapter {
     private BaseMetricStorage metricStorage;
     private Map<String, String> agentTenantIdHeader;
     private AgentRestServer agentRestServer;
+    private BaseRestServerGenerator baseRestServerGenerator;
 
     public HawkularStorageAdapter() {
     }
@@ -72,11 +73,13 @@ public class HawkularStorageAdapter implements StorageAdapter {
             AgentCoreEngineConfiguration.StorageAdapterConfiguration config,
             int autoDiscoveryScanPeriodSeconds,
             Diagnostics diag,
-            HttpClientBuilder httpClientBuilder) {
+            HttpClientBuilder httpClientBuilder,
+            BaseRestServerGenerator restServerGenerator) {
         this.config = config;
         this.diagnostics = diag;
         this.httpClientBuilder = httpClientBuilder;
         this.agentTenantIdHeader = getTenantHeader(config.getTenantId());
+        this.baseRestServerGenerator = restServerGenerator;
 
         switch (config.getType()) {
             case HAWKULAR:
@@ -108,14 +111,9 @@ public class HawkularStorageAdapter implements StorageAdapter {
                         diagnostics);
 
                 // build the HOSA rest server
-                BaseRestServerGenerator restServerGenerator = new BaseRestServerGenerator(
-                        new BaseRestServerGenerator.Configuration.Builder()
-                                .username(config.getHosaEndpointUsername())
-                                .password(config.getHosaEndpointPassword())
-                                .address(config.getHosaEndpointAddress())
-                                .port(config.getHosaEndpointPort())
-                                .useSSL(config.getHosaEndpointUseSSL())
-                                .build());
+                if (restServerGenerator == null) {
+                    throw new IllegalArgumentException("HOSA mode requires a BaseRestServerGenerator. Please report this bug.");
+                }
                 agentRestServer = new HosaRestServer(
                         restServerGenerator,
                         (CacheMetricStorage) this.metricStorage,

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/HawkularStorageAdapter.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/HawkularStorageAdapter.java
@@ -110,10 +110,11 @@ public class HawkularStorageAdapter implements StorageAdapter {
                 // build the HOSA rest server
                 BaseRestServerGenerator restServerGenerator = new BaseRestServerGenerator(
                         new BaseRestServerGenerator.Configuration.Builder()
-                                .username("jdoe")
-                                .password("password")
-                                .address("0.0.0.0")
-                                .port(8090)
+                                .username(config.getHosaEndpointUsername())
+                                .password(config.getHosaEndpointPassword())
+                                .address(config.getHosaEndpointAddress())
+                                .port(config.getHosaEndpointPort())
+                                .useSSL(config.getHosaEndpointUseSSL())
                                 .build());
                 agentRestServer = new HosaRestServer(
                         restServerGenerator,

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/StorageAdapter.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/storage/StorageAdapter.java
@@ -24,6 +24,7 @@ import org.hawkular.agent.monitor.api.MetricStorage;
 import org.hawkular.agent.monitor.api.NotificationStorage;
 import org.hawkular.agent.monitor.config.AgentCoreEngineConfiguration;
 import org.hawkular.agent.monitor.diagnostics.Diagnostics;
+import org.hawkular.agent.monitor.util.BaseRestServerGenerator;
 
 public interface StorageAdapter extends MetricStorage, AvailStorage, InventoryStorage, NotificationStorage {
 
@@ -35,13 +36,15 @@ public interface StorageAdapter extends MetricStorage, AvailStorage, InventorySt
      * @param autoDiscoveryScanPeriodSeconds the auto discovery frequency in seconds
      * @param diag the object used to track internal diagnostic data for the storage adapter
      * @param httpClientBuilder used to communicate with the storage server
+     * @param baseRestServerGenerator used to listen for additional commands being sent to the agent
      */
     void initialize(
             String feedId,
             AgentCoreEngineConfiguration.StorageAdapterConfiguration config,
             int autoDiscoveryScanPeriodSeconds,
             Diagnostics diag,
-            HttpClientBuilder httpClientBuilder);
+            HttpClientBuilder httpClientBuilder,
+            BaseRestServerGenerator baseRestServerGenerator);
 
     /**
      * Clean up and stop whatever the storage adapter is doing.

--- a/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/util/BaseRestServerGenerator.java
+++ b/hawkular-agent-core/src/main/java/org/hawkular/agent/monitor/util/BaseRestServerGenerator.java
@@ -16,8 +16,6 @@
  */
 package org.hawkular.agent.monitor.util;
 
-import java.security.KeyStore;
-
 import javax.net.ssl.SSLContext;
 import javax.xml.bind.DatatypeConverter;
 
@@ -47,9 +45,6 @@ public class BaseRestServerGenerator {
             private int port;
             private String username;
             private String password;
-            private boolean useSSL;
-            private String keystorePath;
-            private String keystorePassword;
             private SSLContext sslContext;
 
             public Builder() {
@@ -57,8 +52,7 @@ public class BaseRestServerGenerator {
             }
 
             public Configuration build() {
-                return new Configuration(address, port, username, password, useSSL, keystorePath,
-                keystorePassword, sslContext);
+                return new Configuration(address, port, username, password, sslContext);
             }
 
             public Builder address(String address) {
@@ -81,22 +75,6 @@ public class BaseRestServerGenerator {
                 return this;
             }
 
-
-            public Builder useSSL(boolean useSSL) {
-                this.useSSL = useSSL;
-                return this;
-            }
-
-            public Builder keystorePath(String keystorePath) {
-                this.keystorePath = keystorePath;
-                return this;
-            }
-
-            public Builder keystorePassword(String keystorePassword) {
-                this.keystorePassword = keystorePassword;
-                return this;
-            }
-
             public Builder sslContext(SSLContext sslContext) {
                 this.sslContext = sslContext;
                 return this;
@@ -107,20 +85,13 @@ public class BaseRestServerGenerator {
         private final int port;
         private final String username;
         private final String password;
-        private final boolean useSSL;
-        private final String keystorePath;
-        private final String keystorePassword;
         private final SSLContext sslContext;
 
-        private Configuration(String address, int port, String username, String password, boolean useSSL,
-                              String keystorePath, String keystorePassword, SSLContext sslContext) {
+        private Configuration(String address, int port, String username, String password, SSLContext sslContext) {
             this.address = address;
             this.port = port;
             this.username = username;
             this.password = password;
-            this.useSSL = useSSL;
-            this.keystorePath = keystorePath;
-            this.keystorePassword = keystorePassword;
             this.sslContext = sslContext;
         }
 
@@ -140,18 +111,6 @@ public class BaseRestServerGenerator {
             return password;
         }
 
-        public boolean isUseSSL() {
-            return useSSL;
-        }
-
-        public String getKeystorePath() {
-            return keystorePath;
-        }
-
-        public String getKeystorePassword() {
-            return keystorePassword;
-        }
-
         public SSLContext getSslContext() {
             return sslContext;
         }
@@ -168,25 +127,7 @@ public class BaseRestServerGenerator {
         restServer.setHostname(configuration.getAddress());
         restServer.setPort(configuration.getPort());
 
-        if (this.configuration.isUseSSL()) {
-            SSLContext theSslContextToUse;
-            if (this.configuration.getSslContext() == null) {
-                if (this.configuration.getKeystorePath() != null) {
-                    KeyStore keyStore = SSLUtil.loadKeystore(this.configuration.getKeystorePath(),
-                        this.configuration.getKeystorePassword());
-                    theSslContextToUse = SSLUtil.buildSSLContext(keyStore, this.configuration.getKeystorePassword(),
-                    null); // No need for a truststore here, as, this is going to act as a server
-                } else {
-                    theSslContextToUse = null; // Rely on the JVM default
-                }
-            } else {
-                theSslContextToUse = this.configuration.getSslContext();
-            }
-
-            if (theSslContextToUse != null) {
-                restServer.setSSLContext(configuration.getSslContext());
-            }
-        }
+        restServer.setSSLContext(this.configuration.getSslContext());
 
         if (this.configuration.getUsername() != null && !this.configuration.getUsername().isEmpty()) {
             restServer.addPreprocessor(new HttpBasicAuthenticationRestServerPreprocessor(

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/ConfigConverter.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/ConfigConverter.java
@@ -129,7 +129,6 @@ public class ConfigConverter {
                 config.getStorageAdapter().getHosaEndpointPort(),
                 config.getStorageAdapter().getHosaEndpointUsername(),
                 config.getStorageAdapter().getHosaEndpointPassword(),
-                config.getStorageAdapter().getHosaEndpointUseSsl(),
                 config.getStorageAdapter().getHosaEndpointSecurityRealm());
 
         ProtocolConfiguration<DMRNodeLocation> dmrConfiguration = buildDmrConfiguration(config);

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/ConfigConverter.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/ConfigConverter.java
@@ -124,7 +124,13 @@ public class ConfigConverter {
                 null, // we use security realm exclusively
                 config.getStorageAdapter().getSecurityRealmName(),
                 config.getStorageAdapter().getConnectTimeoutSecs(),
-                config.getStorageAdapter().getReadTimeoutSecs());
+                config.getStorageAdapter().getReadTimeoutSecs(),
+                config.getStorageAdapter().getHosaEndpointAddress(),
+                config.getStorageAdapter().getHosaEndpointPort(),
+                config.getStorageAdapter().getHosaEndpointUsername(),
+                config.getStorageAdapter().getHosaEndpointPassword(),
+                config.getStorageAdapter().getHosaEndpointUseSsl(),
+                config.getStorageAdapter().getHosaEndpointSecurityRealm());
 
         ProtocolConfiguration<DMRNodeLocation> dmrConfiguration = buildDmrConfiguration(config);
         ProtocolConfiguration<JMXNodeLocation> jmxConfiguration = buildJmxConfiguration(config);

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/StorageAdapter.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/StorageAdapter.java
@@ -83,9 +83,6 @@ public class StorageAdapter implements Validatable {
     @JsonProperty("hosa-endpoint-password")
     private StringExpression hosaEndpointPassword;
 
-    @JsonProperty("hosa-endpoint-use-ssl")
-    private BooleanExpression hosaEndpointUseSsl = new BooleanExpression(false);
-
     @JsonProperty("hosa-endpoint-security-realm")
     private String hosaEndpointSecurityRealm;
 
@@ -109,7 +106,6 @@ public class StorageAdapter implements Validatable {
         this.hosaEndpointPort = original.hosaEndpointPort == null ? null : new IntegerExpression(original.hosaEndpointPort);
         this.hosaEndpointUsername = original.hosaEndpointUsername == null ? null : new StringExpression(original.hosaEndpointUsername);
         this.hosaEndpointPassword = original.hosaEndpointPassword == null ? null : new StringExpression(original.hosaEndpointPassword);
-        this.hosaEndpointUseSsl = original.hosaEndpointUseSsl == null ? null : new BooleanExpression(original.hosaEndpointUseSsl);
         this.hosaEndpointSecurityRealm = original.hosaEndpointSecurityRealm;
     }
 
@@ -305,18 +301,6 @@ public class StorageAdapter implements Validatable {
             this.hosaEndpointPassword.set(new StringValue(hosaEndpointPassword));
         } else {
             this.hosaEndpointPassword = new StringExpression(new StringValue(hosaEndpointPassword));
-        }
-    }
-
-    public Boolean getHosaEndpointUseSsl() {
-        return hosaEndpointUseSsl == null ? null : hosaEndpointUseSsl.get();
-    }
-
-    public void setHosaEndpointUseSsl(Boolean hosaEndpointUseSsl) {
-        if (this.hosaEndpointUseSsl != null) {
-            this.hosaEndpointUseSsl.set(hosaEndpointUseSsl);
-        } else {
-            this.hosaEndpointUseSsl = new BooleanExpression(hosaEndpointUseSsl);
         }
     }
 

--- a/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/StorageAdapter.java
+++ b/hawkular-javaagent/src/main/java/org/hawkular/agent/javaagent/config/StorageAdapter.java
@@ -71,6 +71,24 @@ public class StorageAdapter implements Validatable {
     @JsonProperty("read-timeout-secs")
     private Integer readTimeoutSecs = 120;
 
+    @JsonProperty("hosa-endpoint-address")
+    private StringExpression hosaEndpointAddress = new StringExpression("0.0.0.0");
+
+    @JsonProperty("hosa-endpoint-port")
+    private IntegerExpression hosaEndpointPort = new IntegerExpression(8090);
+
+    @JsonProperty("hosa-endpoint-username")
+    private StringExpression hosaEndpointUsername;
+
+    @JsonProperty("hosa-endpoint-password")
+    private StringExpression hosaEndpointPassword;
+
+    @JsonProperty("hosa-endpoint-use-ssl")
+    private BooleanExpression hosaEndpointUseSsl = new BooleanExpression(false);
+
+    @JsonProperty("hosa-endpoint-security-realm")
+    private String hosaEndpointSecurityRealm;
+
     public StorageAdapter() {
     }
 
@@ -87,6 +105,12 @@ public class StorageAdapter implements Validatable {
         this.hawkularContext = original.hawkularContext;
         this.connectTimeoutSecs = original.connectTimeoutSecs;
         this.readTimeoutSecs = original.readTimeoutSecs;
+        this.hosaEndpointAddress = original.hosaEndpointAddress == null ? null : new StringExpression(original.hosaEndpointAddress);
+        this.hosaEndpointPort = original.hosaEndpointPort == null ? null : new IntegerExpression(original.hosaEndpointPort);
+        this.hosaEndpointUsername = original.hosaEndpointUsername == null ? null : new StringExpression(original.hosaEndpointUsername);
+        this.hosaEndpointPassword = original.hosaEndpointPassword == null ? null : new StringExpression(original.hosaEndpointPassword);
+        this.hosaEndpointUseSsl = original.hosaEndpointUseSsl == null ? null : new BooleanExpression(original.hosaEndpointUseSsl);
+        this.hosaEndpointSecurityRealm = original.hosaEndpointSecurityRealm;
     }
 
     /**
@@ -234,5 +258,73 @@ public class StorageAdapter implements Validatable {
 
     public void setReadTimeoutSecs(Integer readTimeoutSecs) {
         this.readTimeoutSecs = readTimeoutSecs;
+    }
+
+    public String getHosaEndpointAddress() {
+        return hosaEndpointAddress == null ? null : hosaEndpointAddress.get().toString();
+    }
+
+    public void setHosaEndpointAddress(String hosaEndpointAddress) {
+        if (this.hosaEndpointAddress != null) {
+            this.hosaEndpointAddress.set(new StringValue(hosaEndpointAddress));
+        } else {
+            this.hosaEndpointAddress = new StringExpression(new StringValue(hosaEndpointAddress));
+        }
+    }
+
+    public Integer getHosaEndpointPort() {
+        return hosaEndpointPort == null ? null : hosaEndpointPort.get();
+    }
+
+    public void setHosaEndpointPort(Integer hosaEndpointPort) {
+        if (this.hosaEndpointPort != null) {
+            this.hosaEndpointPort.set(hosaEndpointPort);
+        } else {
+            this.hosaEndpointPort = new IntegerExpression(hosaEndpointPort);
+        }
+    }
+
+    public String getHosaEndpointUsername() {
+        return hosaEndpointUsername == null ? null : hosaEndpointUsername.get().toString();
+    }
+
+    public void setHosaEndpointUsername(String hosaEndpointUsername) {
+        if (this.hosaEndpointUsername != null) {
+            this.hosaEndpointUsername.set(new StringValue(hosaEndpointUsername));
+        } else {
+            this.hosaEndpointUsername = new StringExpression(new StringValue(hosaEndpointUsername));
+        }
+    }
+
+    public String getHosaEndpointPassword() {
+        return hosaEndpointPassword == null ? null : hosaEndpointPassword.get().toString();
+    }
+
+    public void setHosaEndpointPassword(String hosaEndpointPassword) {
+        if (this.hosaEndpointPassword != null) {
+            this.hosaEndpointPassword.set(new StringValue(hosaEndpointPassword));
+        } else {
+            this.hosaEndpointPassword = new StringExpression(new StringValue(hosaEndpointPassword));
+        }
+    }
+
+    public Boolean getHosaEndpointUseSsl() {
+        return hosaEndpointUseSsl == null ? null : hosaEndpointUseSsl.get();
+    }
+
+    public void setHosaEndpointUseSsl(Boolean hosaEndpointUseSsl) {
+        if (this.hosaEndpointUseSsl != null) {
+            this.hosaEndpointUseSsl.set(hosaEndpointUseSsl);
+        } else {
+            this.hosaEndpointUseSsl = new BooleanExpression(hosaEndpointUseSsl);
+        }
+    }
+
+    public String getHosaEndpointSecurityRealm() {
+        return hosaEndpointSecurityRealm;
+    }
+
+    public void setHosaEndpointSecurityRealm(String hosaEndpointSecurityRealm) {
+        this.hosaEndpointSecurityRealm = hosaEndpointSecurityRealm;
     }
 }

--- a/hawkular-wildfly-agent-feature-pack/src/main/resources/modules/system/add-ons/hawkular-agent/org/hawkular/agent/main/module.xml
+++ b/hawkular-wildfly-agent-feature-pack/src/main/resources/modules/system/add-ons/hawkular-agent/org/hawkular/agent/main/module.xml
@@ -54,6 +54,16 @@
     <artifact name="${httpmime}" />
      -->
 
+    <!-- RestExpress (for HOSA rest server) -->
+    <artifact name="${com.strategicgains:RestExpress}" />
+    <artifact name="${com.strategicgains:RestExpress-Common}" />
+    <artifact name="${com.strategicgains:DateAdapterJ}" />
+    <artifact name="${com.thoughtworks.xstream:xstream}" />
+    <artifact name="${io.netty:netty-all}" />
+    <artifact name="${org.owasp.encoder:encoder}" />
+    <artifact name="${xmlpull:xmlpull}" />
+    <artifact name="${com.jcraft:jzlib}" />
+
   </resources>
 
   <dependencies>

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -981,7 +981,6 @@ public class MonitorServiceConfigurationBuilder {
         int hosaEndpointPort = getInt(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_PORT);
         String hosaEndpointUsername = getString(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_USERNAME);
         String hosaEndpointPassword = getString(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_PASSWORD);
-        boolean hosaEndpointUseSSL = getBoolean(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_USE_SSL);
         String hosaEndpointSecurityRealm = getString(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_SECURITY_REALM);
 
         if (useSSL) {
@@ -1005,7 +1004,7 @@ public class MonitorServiceConfigurationBuilder {
                 serverOutboundSocketBindingRef, metricsContext, feedcommContext, hawkularContext,
                 keystorePath, keystorePassword, securityRealm, connectTimeoutSeconds, readTimeoutSeconds,
                 hosaEndpointAddress, hosaEndpointPort, hosaEndpointUsername, hosaEndpointPassword,
-                hosaEndpointUseSSL, hosaEndpointSecurityRealm);
+                hosaEndpointSecurityRealm);
     }
 
     private static GlobalConfiguration determineGlobalConfig(ModelNode config, OperationContext context)

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/MonitorServiceConfigurationBuilder.java
@@ -977,6 +977,12 @@ public class MonitorServiceConfigurationBuilder {
         StorageReportTo type = AgentCoreEngineConfiguration.StorageReportTo.valueOf(typeStr.toUpperCase());
         int connectTimeoutSeconds = getInt(storageAdapterConfig, context, StorageAttributes.CONNECT_TIMEOUT_SECONDS);
         int readTimeoutSeconds = getInt(storageAdapterConfig, context, StorageAttributes.READ_TIMEOUT_SECONDS);
+        String hosaEndpointAddress = getString(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_ADDRESS);
+        int hosaEndpointPort = getInt(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_PORT);
+        String hosaEndpointUsername = getString(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_USERNAME);
+        String hosaEndpointPassword = getString(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_PASSWORD);
+        boolean hosaEndpointUseSSL = getBoolean(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_USE_SSL);
+        String hosaEndpointSecurityRealm = getString(storageAdapterConfig, context, StorageAttributes.HOSA_ENDPOINT_SECURITY_REALM);
 
         if (useSSL) {
             if (securityRealm == null) {
@@ -997,7 +1003,9 @@ public class MonitorServiceConfigurationBuilder {
 
         return new StorageAdapterConfiguration(type, username, password, tenantId, feedId, url, useSSL,
                 serverOutboundSocketBindingRef, metricsContext, feedcommContext, hawkularContext,
-                keystorePath, keystorePassword, securityRealm, connectTimeoutSeconds, readTimeoutSeconds);
+                keystorePath, keystorePassword, securityRealm, connectTimeoutSeconds, readTimeoutSeconds,
+                hosaEndpointAddress, hosaEndpointPort, hosaEndpointUsername, hosaEndpointPassword,
+                hosaEndpointUseSSL, hosaEndpointSecurityRealm);
     }
 
     private static GlobalConfiguration determineGlobalConfig(ModelNode config, OperationContext context)

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/StorageAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/StorageAttributes.java
@@ -144,6 +144,42 @@ public interface StorageAttributes {
                     .setDefaultValue(new ModelNode(120)) /* e.g. bulk inserts may take long */
                     .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
+    SimpleAttributeDefinition HOSA_ENDPOINT_ADDRESS = new SimpleAttributeDefinitionBuilder("hosa-endpoint-address",
+            ModelType.STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+    SimpleAttributeDefinition HOSA_ENDPOINT_PORT = new SimpleAttributeDefinitionBuilder("hosa-endpoint-port",
+            ModelType.INT)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+    SimpleAttributeDefinition HOSA_ENDPOINT_USERNAME = new SimpleAttributeDefinitionBuilder("hosa-endpoint-username",
+            ModelType.STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+    SimpleAttributeDefinition HOSA_ENDPOINT_PASSWORD = new SimpleAttributeDefinitionBuilder("hosa-endpoint-password",
+            ModelType.STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+    SimpleAttributeDefinition HOSA_ENDPOINT_USE_SSL = new SimpleAttributeDefinitionBuilder("hosa-endpoint-use-ssl",
+            ModelType.BOOLEAN)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+    SimpleAttributeDefinition HOSA_ENDPOINT_SECURITY_REALM = new SimpleAttributeDefinitionBuilder("hosa-endpoint-security-realm",
+            ModelType.STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
 
     AttributeDefinition[] ATTRIBUTES = {
             TYPE,
@@ -160,7 +196,13 @@ public interface StorageAttributes {
             METRICS_CONTEXT,
             FEEDCOMM_CONTEXT,
             CONNECT_TIMEOUT_SECONDS,
-            READ_TIMEOUT_SECONDS
+            READ_TIMEOUT_SECONDS,
+            HOSA_ENDPOINT_ADDRESS,
+            HOSA_ENDPOINT_PORT,
+            HOSA_ENDPOINT_USERNAME,
+            HOSA_ENDPOINT_PASSWORD,
+            HOSA_ENDPOINT_USE_SSL,
+            HOSA_ENDPOINT_SECURITY_REALM
     };
 
 }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/StorageAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/StorageAttributes.java
@@ -149,12 +149,14 @@ public interface StorageAttributes {
             .setAllowNull(true)
             .setAllowExpression(true)
             .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setDefaultValue(new ModelNode("0.0.0.0"))
             .build();
     SimpleAttributeDefinition HOSA_ENDPOINT_PORT = new SimpleAttributeDefinitionBuilder("hosa-endpoint-port",
             ModelType.INT)
             .setAllowNull(true)
             .setAllowExpression(true)
             .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setDefaultValue(new ModelNode(8090))
             .build();
     SimpleAttributeDefinition HOSA_ENDPOINT_USERNAME = new SimpleAttributeDefinitionBuilder("hosa-endpoint-username",
             ModelType.STRING)

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/StorageAttributes.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/extension/StorageAttributes.java
@@ -168,12 +168,6 @@ public interface StorageAttributes {
             .setAllowExpression(true)
             .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
-    SimpleAttributeDefinition HOSA_ENDPOINT_USE_SSL = new SimpleAttributeDefinitionBuilder("hosa-endpoint-use-ssl",
-            ModelType.BOOLEAN)
-            .setAllowNull(true)
-            .setAllowExpression(true)
-            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .build();
     SimpleAttributeDefinition HOSA_ENDPOINT_SECURITY_REALM = new SimpleAttributeDefinitionBuilder("hosa-endpoint-security-realm",
             ModelType.STRING)
             .setAllowNull(true)
@@ -201,7 +195,6 @@ public interface StorageAttributes {
             HOSA_ENDPOINT_PORT,
             HOSA_ENDPOINT_USERNAME,
             HOSA_ENDPOINT_PASSWORD,
-            HOSA_ENDPOINT_USE_SSL,
             HOSA_ENDPOINT_SECURITY_REALM
     };
 

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -175,7 +175,6 @@ public class MonitorService extends AgentCoreEngine implements Service<MonitorSe
                             bootStorageAdapter.getHosaEndpointPort(),
                             bootStorageAdapter.getHosaEndpointUsername(),
                             bootStorageAdapter.getHosaEndpointPassword(),
-                            bootStorageAdapter.getHosaEndpointUseSSL(),
                             bootStorageAdapter.getHosaEndpointSecurityRealm());
 
             return bootConfiguration.cloneWith(runtimeStorageAdapter);

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -170,7 +170,13 @@ public class MonitorService extends AgentCoreEngine implements Service<MonitorSe
                             bootStorageAdapter.getKeystorePassword(),
                             bootStorageAdapter.getSecurityRealm(),
                             bootStorageAdapter.getConnectTimeoutSeconds(),
-                            bootStorageAdapter.getReadTimeoutSeconds());
+                            bootStorageAdapter.getReadTimeoutSeconds(),
+                            bootStorageAdapter.getHosaEndpointAddress(),
+                            bootStorageAdapter.getHosaEndpointPort(),
+                            bootStorageAdapter.getHosaEndpointUsername(),
+                            bootStorageAdapter.getHosaEndpointPassword(),
+                            bootStorageAdapter.getHosaEndpointUseSSL(),
+                            bootStorageAdapter.getHosaEndpointSecurityRealm());
 
             return bootConfiguration.cloneWith(runtimeStorageAdapter);
         }

--- a/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
+++ b/hawkular-wildfly-agent/src/main/java/org/hawkular/agent/monitor/service/MonitorService.java
@@ -275,6 +275,20 @@ public class MonitorService extends AgentCoreEngine implements Service<MonitorSe
                     trustStoreOnly);
         }
 
+        // get the security realm ssl context for the hosa storage adapter (if any)
+        if (storageAdapterConfig.getHosaEndpointSecurityRealm() != null) {
+            InjectedValue<SSLContext> iv = new InjectedValue<>();
+            trustOnlySSLContextInjectedValues.put(storageAdapterConfig.getHosaEndpointSecurityRealm(), iv);
+
+            // We will act as a server
+            boolean trustStoreOnly = false;
+            SSLContextService.ServiceUtil.addDependency(
+                    bldr,
+                    iv,
+                    SecurityRealm.ServiceUtil.createServiceName(storageAdapterConfig.getHosaEndpointSecurityRealm()),
+                    trustStoreOnly);
+        }
+
         // get the security realms for any configured remote servers that require ssl
         for (EndpointConfiguration endpoint : bootConfiguration.getDmrConfiguration().getEndpoints().values()) {
             String securityRealm = endpoint.getSecurityRealm();

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -66,7 +66,6 @@ hawkular-wildfly-agent.storage-adapter.hosa-endpoint-address=Adresss that HOSA e
 hawkular-wildfly-agent.storage-adapter.hosa-endpoint-port=Port that HOSA endpoint will bind to
 hawkular-wildfly-agent.storage-adapter.hosa-endpoint-username=If specified, enable basic auth on HOSA endpoint with this username
 hawkular-wildfly-agent.storage-adapter.hosa-endpoint-password=If specified, enable basic auth on HOSA endpoint with this password
-hawkular-wildfly-agent.storage-adapter.hosa-endpoint-use-ssl=Specify if HOSA endpoint should be over https
 hawkular-wildfly-agent.storage-adapter.hosa-endpoint-security-realm=Specify the security-realm HOSA endpoint will use
 
 # DIAGNOSTICS

--- a/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
+++ b/hawkular-wildfly-agent/src/main/resources/org/hawkular/agent/monitor/extension/LocalDescriptions.properties
@@ -62,6 +62,13 @@ hawkular-wildfly-agent.storage-adapter.type=Name of the storage adapter type (ha
 hawkular-wildfly-agent.storage-adapter.connect-timeout-secs=Timeout for connecting to the storage backend in seconds
 hawkular-wildfly-agent.storage-adapter.read-timeout-secs=Read timeout for the storage backend in seconds
 
+hawkular-wildfly-agent.storage-adapter.hosa-endpoint-address=Adresss that HOSA endpoint will bind to
+hawkular-wildfly-agent.storage-adapter.hosa-endpoint-port=Port that HOSA endpoint will bind to
+hawkular-wildfly-agent.storage-adapter.hosa-endpoint-username=If specified, enable basic auth on HOSA endpoint with this username
+hawkular-wildfly-agent.storage-adapter.hosa-endpoint-password=If specified, enable basic auth on HOSA endpoint with this password
+hawkular-wildfly-agent.storage-adapter.hosa-endpoint-use-ssl=Specify if HOSA endpoint should be over https
+hawkular-wildfly-agent.storage-adapter.hosa-endpoint-security-realm=Specify the security-realm HOSA endpoint will use
+
 # DIAGNOSTICS
 
 hawkular-wildfly-agent.diagnostics=Diagnostics for the Hawkular WildFly Agent service itself

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -70,6 +70,12 @@
     <xs:attribute name="feedcomm-context"      type="xs:string"/>
     <xs:attribute name="connect-timeout-secs"  type="xs:int"/>
     <xs:attribute name="read-timeout-secs"     type="xs:int"/>
+    <xs:attribute name="hosa-endpoint-address"         type="xs:string"/>
+    <xs:attribute name="hosa-endpoint-port"            type="xs:int"/>
+    <xs:attribute name="hosa-endpoint-username"        type="xs:string"/>
+    <xs:attribute name="hosa-endpoint-password"        type="xs:string"/>
+    <xs:attribute name="hosa-endpoint-use-ssl"         type="xs:boolean"/>
+    <xs:attribute name="hosa-endpoint-security-realm"  type="xs:string"/>
   </xs:complexType>
 
   <xs:simpleType name="adapterType">

--- a/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
+++ b/hawkular-wildfly-agent/src/main/resources/schema/hawkular-agent-monitor-subsystem.xsd
@@ -74,7 +74,6 @@
     <xs:attribute name="hosa-endpoint-port"            type="xs:int"/>
     <xs:attribute name="hosa-endpoint-username"        type="xs:string"/>
     <xs:attribute name="hosa-endpoint-password"        type="xs:string"/>
-    <xs:attribute name="hosa-endpoint-use-ssl"         type="xs:boolean"/>
     <xs:attribute name="hosa-endpoint-security-realm"  type="xs:string"/>
   </xs:complexType>
 


### PR DESCRIPTION
This currently works with javaagent and makes it easier to configure the hosa-endpoint data.

There are some issues (not introduced by this PR)

a) ~~It doesn't work on hawkular-wildfly-agent, still need to add the libs to wildfly configuration~~
b) ~~hosa-endpoint-usessl might be redundant~~
  Removed the usessl, only the security-realm is required
c) ~~Need some glue-code for the security-realm to make it work.~~ 
  done

Will start doing these and push here.